### PR TITLE
Add sponsor takedown support

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -3,9 +3,9 @@ class AccountsController < ApplicationController
 
   def index
     if params[:active] == 'true'
-      scope = Account.all.has_sponsors_listing.where('active_sponsors_count > 0')
+      scope = Account.visible.has_sponsors_listing.where('active_sponsors_count > 0')
     else
-      scope = Account.all.has_sponsors_listing
+      scope = Account.visible.has_sponsors_listing
     end
     scope = scope.kind(params[:kind]) if params[:kind].present?
 
@@ -25,7 +25,7 @@ class AccountsController < ApplicationController
 
   def show
 
-    @account = Account.find_by_login(params[:id].downcase)
+    @account = Account.visible.find_by_login(params[:id].downcase)
     raise ActiveRecord::RecordNotFound if @account.nil?
 
     if @account.active_sponsorships_count > 0 && @account.active_sponsors_count > 0
@@ -36,9 +36,9 @@ class AccountsController < ApplicationController
 
   def sponsors
     if params[:active] == 'true'
-      scope = Account.all.where('active_sponsorships_count > 0')
+      scope = Account.visible.where('active_sponsorships_count > 0')
     else
-      scope = Account.all.where('sponsorships_count > 0')
+      scope = Account.visible.where('sponsorships_count > 0')
     end
     scope = scope.kind(params[:kind]) if params[:kind].present?
 
@@ -66,7 +66,7 @@ class AccountsController < ApplicationController
   end
 
   def charts
-    @accounts_by_total_sponsorships = Account.all
+    @accounts_by_total_sponsorships = Account.visible
       .has_sponsors_listing
       .order(sponsors_count: :desc)
       .limit(1000)
@@ -74,7 +74,7 @@ class AccountsController < ApplicationController
     
     @top_50_accounts_by_total_sponsorships = @accounts_by_total_sponsorships.first(50)
 
-    @top_1000_users_by_total_sponsorships = Account.users
+    @top_1000_users_by_total_sponsorships = Account.visible.users
       .has_sponsors_listing
       .order(sponsors_count: :desc)
       .limit(1000)
@@ -82,7 +82,7 @@ class AccountsController < ApplicationController
     
     @top_50_users_by_total_sponsorships = @top_1000_users_by_total_sponsorships.first(50)
 
-    @top_1000_organizations_by_total_sponsorships = Account.organizations
+    @top_1000_organizations_by_total_sponsorships = Account.visible.organizations
       .has_sponsors_listing
       .order(sponsors_count: :desc)
       .limit(1000)
@@ -99,21 +99,21 @@ class AccountsController < ApplicationController
   end
 
   def sponsor_charts
-    @accounts_by_total_sponsors = Account.all
+    @accounts_by_total_sponsors = Account.visible
       .where('sponsorships_count > 0').order('sponsorships_count desc')
       .limit(1000)
       .pluck(:login, :sponsorships_count)
 
     @top_50_accounts_by_total_sponsors = @accounts_by_total_sponsors.first(50)
     
-    @top_1000_users_by_total_sponsors = Account.users
+    @top_1000_users_by_total_sponsors = Account.visible.users
       .where('sponsorships_count > 0').order('sponsorships_count desc')
       .limit(1000)
       .pluck(:login, :sponsorships_count)
     
     @top_50_users_by_total_sponsors = @top_1000_users_by_total_sponsors.first(50)
 
-    @top_1000_organizations_by_total_sponsors = Account.organizations
+    @top_1000_organizations_by_total_sponsors = Account.visible.organizations
       .where('sponsorships_count > 0').order('sponsorships_count desc')
       .limit(1000)
       .pluck(:login, :sponsorships_count)

--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -3,16 +3,16 @@ class Api::V1::AccountsController < Api::V1::ApplicationController
 
   def index
     if params[:active] == 'true'
-      scope = Account.all.has_sponsors_listing.where('active_sponsors_count > 0')
+      scope = Account.visible.has_sponsors_listing.where('active_sponsors_count > 0')
     else
-      scope = Account.all.has_sponsors_listing
+      scope = Account.visible.has_sponsors_listing
     end
     scope = scope.order('sponsors_count desc, updated_at DESC')
     @pagy, @accounts = pagy(scope)
   end
 
   def show
-    @account = Account.find_by_login(params[:id].downcase)
+    @account = Account.visible.find_by_login(params[:id].downcase)
     if @account.nil?
       @account = Account.attempt_import_from_repos(params[:id].downcase)
       raise ActiveRecord::RecordNotFound if @account.nil?
@@ -21,9 +21,9 @@ class Api::V1::AccountsController < Api::V1::ApplicationController
 
   def sponsors
     if params[:active] == 'true'
-      scope = Account.all.where('active_sponsorships_count > 0')
+      scope = Account.visible.where('active_sponsorships_count > 0')
     else
-      scope = Account.all.where('sponsorships_count > 0')
+      scope = Account.visible.where('sponsorships_count > 0')
     end
     scope = scope.order('active_sponsorships_count desc, sponsorships_count desc, updated_at DESC')
     @pagy, @accounts = pagy(scope)
@@ -31,7 +31,7 @@ class Api::V1::AccountsController < Api::V1::ApplicationController
   end
 
   def sponsorships
-    @account = Account.find_by_login(params[:account_id].downcase)
+    @account = Account.visible.find_by_login(params[:account_id].downcase)
     raise ActiveRecord::RecordNotFound unless @account
     scope = @account.sponsorships_as_maintainer.order('created_at DESC').includes(:maintainer, :funder)
     @pagy, @sponsorships = pagy(scope)
@@ -39,7 +39,7 @@ class Api::V1::AccountsController < Api::V1::ApplicationController
   end
 
   def account_sponsors
-    @account = Account.find_by_login(params[:account_id].downcase)
+    @account = Account.visible.find_by_login(params[:account_id].downcase)
     raise ActiveRecord::RecordNotFound unless @account
     scope = @account.sponsorships_as_funder.order('created_at DESC').includes(:maintainer, :funder)
     @pagy, @sponsorships = pagy(scope)
@@ -47,7 +47,7 @@ class Api::V1::AccountsController < Api::V1::ApplicationController
   end
 
   def sponsor_logins
-    logins = Account.has_sponsors_listing.order('login').pluck(:login)
+    logins = Account.visible.has_sponsors_listing.order('login').pluck(:login)
     render json: logins
   end
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -19,6 +19,8 @@ class Account < ApplicationRecord
   has_many :maintained_accounts, through: :sponsorships_as_funder, source: :maintainer
   has_many :funder_accounts, through: :sponsorships_as_maintainer, source: :funder
 
+  scope :visible, -> { where(hidden: false) }
+  scope :hidden, -> { where(hidden: true) }
   scope :has_sponsors_listing, -> { where(has_sponsors_listing: true) }
   scope :has_sponsors_profile, -> { where('length(sponsor_profile::text) > 2') }
   scope :has_active_sponsorships, -> { where('active_sponsorships_count > 0') }
@@ -33,13 +35,13 @@ class Account < ApplicationRecord
   scope :organizations, -> { where("data->>'kind' = ?", 'organization') }
 
   def self.sync_least_recently_synced
-    Account.where(last_synced_at: nil).or(Account.where("last_synced_at < ?", 1.day.ago)).order('last_synced_at asc nulls first').limit(2000).each do |account|
+    visible.where(last_synced_at: nil).or(visible.where("last_synced_at < ?", 1.day.ago)).order('last_synced_at asc nulls first').limit(2000).each do |account|
       account.sync_async
     end
   end
 
   def mutual_accounts
-    Account.where(id: sponsorships_as_funder.active.select(:maintainer_id))
+    Account.visible.where(id: sponsorships_as_funder.active.select(:maintainer_id))
            .where(id: sponsorships_as_maintainer.active.select(:funder_id))
            .order(:login)
   end
@@ -71,7 +73,8 @@ class Account < ApplicationRecord
     logins = JSON.parse(resp.body)
 
     logins.map(&:downcase).each do |login|
-      account = Account.find_by(login: login)
+      account = Account.find_by('lower(login) = ?', login)
+      next if account&.hidden?
 
       if account.nil?
         account = Account.create(login: login, has_sponsors_listing: true)
@@ -91,6 +94,10 @@ class Account < ApplicationRecord
   end
 
   def self.attempt_import_from_repos(login)
+    account = Account.find_by('lower(login) = ?', login.downcase)
+    return if account&.hidden?
+    return account if account
+
     url = "https://repos.ecosyste.ms/api/v1/hosts/GitHub/owners/#{login}"
     resp = Faraday.get(url) do |req|
       req.headers['User-Agent'] = 'sponsors.ecosyste.ms'
@@ -120,6 +127,8 @@ class Account < ApplicationRecord
   end
 
   def sync_all
+    return if hidden?
+
     sync
 
     scrape_sponsored_page
@@ -156,6 +165,8 @@ class Account < ApplicationRecord
   end
 
   def sync_async
+    return if hidden?
+
     AccountWorker.perform_async(id)
   end
 
@@ -264,10 +275,11 @@ class Account < ApplicationRecord
   end
 
   def sync_sponsorships
-    return unless has_sponsors_listing?
+    return if hidden? || !has_sponsors_listing?
     sponsors = fetch_all_sponsors(filter: 'active')
     sponsors.each do |login|
       funder = Account.find_or_create_by(login: login)
+      next if funder.hidden?
       # TODO sync funder
       s = Sponsorship.find_or_create_by(funder: funder, maintainer: self)
       s.update(status: 'active')
@@ -277,6 +289,7 @@ class Account < ApplicationRecord
     past_sponsors = fetch_all_sponsors(filter: 'inactive')
     past_sponsors.each do |login|
       funder = Account.find_or_create_by(login: login)
+      next if funder.hidden?
       # TODO sync funder
       s = Sponsorship.find_or_create_by(funder: funder, maintainer: self)
       s.update(status: 'inactive')
@@ -285,11 +298,14 @@ class Account < ApplicationRecord
   end
 
   def sync_funder
+    return if hidden?
+
     data = fetch_sponsorships_github_graphql
     return unless data.present?
 
     data.each do |sponsor|
       maintainer = Account.find_or_create_by(login: sponsor['maintainer']['login'].downcase)
+      next if maintainer.hidden?
       s = Sponsorship.find_or_create_by(funder: self, maintainer: maintainer)
       s.update(status: 'active')
       maintainer.save
@@ -297,11 +313,14 @@ class Account < ApplicationRecord
   end
 
   def sync_funder_html
+    return if hidden?
+
     data = fetch_sponsorships_github_html
     return unless data.present? && data.is_a?(Array)
 
     data.each do |sponsor|
       maintainer = Account.find_or_create_by(login: sponsor['sponsorableLogin'].downcase)
+      next if maintainer.hidden?
       s = Sponsorship.find_or_create_by(funder: self, maintainer: maintainer)
       s.update(status: sponsor['active'] ? 'active' : 'inactive')
       maintainer.save

--- a/db/migrate/20260730120000_add_hidden_to_accounts.rb
+++ b/db/migrate/20260730120000_add_hidden_to_accounts.rb
@@ -1,0 +1,5 @@
+class AddHiddenToAccounts < ActiveRecord::Migration[8.0]
+  def change
+    add_column :accounts, :hidden, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,25 +10,26 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_07_164706) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_30_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
 
   create_table "accounts", force: :cascade do |t|
-    t.string "login", null: false
-    t.datetime "last_synced_at"
-    t.jsonb "data", default: {}
-    t.boolean "has_sponsors_listing", default: false
-    t.integer "sponsors_count", default: 0
-    t.integer "funded_count", default: 0
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.jsonb "sponsor_profile", default: {}
-    t.integer "sponsorships_count", default: 0
-    t.integer "active_sponsorships_count", default: 0
     t.integer "active_sponsors_count", default: 0
+    t.integer "active_sponsorships_count", default: 0
+    t.datetime "created_at", null: false
+    t.jsonb "data", default: {}
+    t.integer "funded_count", default: 0
+    t.boolean "has_sponsors_listing", default: false
+    t.boolean "hidden", default: false, null: false
+    t.datetime "last_synced_at"
+    t.string "login", null: false
     t.integer "minimum_sponsorship_amount"
+    t.jsonb "sponsor_profile", default: {}
+    t.integer "sponsors_count", default: 0
+    t.integer "sponsorships_count", default: 0
+    t.datetime "updated_at", null: false
     t.index ["active_sponsorships_count"], name: "index_accounts_on_active_sponsorships_count"
     t.index ["has_sponsors_listing"], name: "index_accounts_on_has_sponsors_listing"
     t.index ["login"], name: "index_accounts_on_login", unique: true
@@ -37,10 +38,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_07_164706) do
   end
 
   create_table "sponsorships", force: :cascade do |t|
+    t.datetime "created_at", null: false
     t.bigint "funder_id", null: false
     t.bigint "maintainer_id", null: false
     t.string "status"
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["funder_id"], name: "index_sponsorships_on_funder_id"
     t.index ["maintainer_id"], name: "index_sponsorships_on_maintainer_id"

--- a/lib/tasks/takedown.rake
+++ b/lib/tasks/takedown.rake
@@ -1,0 +1,55 @@
+namespace :takedown do
+  desc "Hide an account and remove its sponsorship data. LOGIN=username"
+  task hide_user: :environment do
+    login = ENV['LOGIN']
+    abort "LOGIN is required" if login.blank?
+
+    account = nil
+    sponsorship_count = 0
+
+    Account.transaction do
+      account = Account.find_by('lower(login) = ?', login.downcase)
+      account ||= Account.create!(login: login.downcase)
+
+      sponsorships = Sponsorship.where(funder_id: account.id)
+                                 .or(Sponsorship.where(maintainer_id: account.id))
+      sponsorship_count = sponsorships.count
+
+      account.update!(
+        hidden: true,
+        last_synced_at: nil,
+        data: {},
+        sponsor_profile: {},
+        has_sponsors_listing: false,
+        sponsors_count: 0,
+        funded_count: 0,
+        sponsorships_count: 0,
+        active_sponsorships_count: 0,
+        active_sponsors_count: 0,
+        minimum_sponsorship_amount: nil
+      )
+      sponsorships.delete_all
+    end
+
+    puts "[sponsors] hidden account #{account.login}"
+    puts "[sponsors] removed #{sponsorship_count} sponsorships for #{account.login}"
+  end
+
+  desc "Report what exists for an account. LOGIN=username"
+  task report: :environment do
+    login = ENV['LOGIN']
+    abort "LOGIN is required" if login.blank?
+
+    account = Account.find_by('lower(login) = ?', login.downcase)
+    sponsorship_count = if account
+      Sponsorship.where(funder_id: account.id)
+                 .or(Sponsorship.where(maintainer_id: account.id))
+                 .count
+    else
+      0
+    end
+
+    state = account ? (account.hidden? ? 'hidden' : 'visible') : 'none'
+    puts "[sponsors] #{login}: account=#{state} sponsorships=#{sponsorship_count}"
+  end
+end

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -47,6 +47,14 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
+  test "should not show a hidden account" do
+    hidden_account = create(:account, :hidden, login: 'hidden-user')
+
+    get account_path(hidden_account)
+
+    assert_response :not_found
+  end
+
   test "should get sponsors page" do
     funder = create(:account, login: 'sponsor')
     create(:sponsorship, funder: funder, maintainer: @account)
@@ -121,6 +129,15 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     # Should include accounts with sponsors listing
     assert_select 'body', text: /#{@account.login}/
     assert_select 'body', text: /#{@account_with_sponsors.login}/
+  end
+
+  test "index should not show hidden accounts" do
+    hidden_account = create(:account, :hidden, login: 'hidden-user')
+
+    get accounts_path
+
+    assert_response :success
+    assert_select 'body', text: /#{hidden_account.login}/, count: 0
   end
 
   test "should filter maintainers by active status" do

--- a/test/controllers/api/v1/accounts_controller_test.rb
+++ b/test/controllers/api/v1/accounts_controller_test.rb
@@ -42,6 +42,15 @@ class Api::V1::AccountsControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
+  test "should not show or import a hidden account" do
+    hidden_account = create(:account, :hidden, login: 'hidden-user')
+
+    get api_v1_account_path(hidden_account)
+
+    assert_response :not_found
+    assert_not_requested :get, hidden_account.repos_api_url
+  end
+
   test "should get sponsors as JSON" do
     get '/api/v1/sponsors'
     assert_response :success
@@ -136,6 +145,16 @@ class Api::V1::AccountsControllerTest < ActionDispatch::IntegrationTest
     json = JSON.parse(response.body)
     assert json.include?(@account.login)
     assert_not json.include?(account_without_listing.login)
+  end
+
+  test "sponsor logins should not include hidden accounts" do
+    hidden_account = create(:account, :hidden, login: 'hidden-user')
+
+    get sponsor_logins_api_v1_accounts_path
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert_not json.include?(hidden_account.login)
   end
 
   test "should handle mixed case login in sponsorships endpoint" do

--- a/test/factories/accounts.rb
+++ b/test/factories/accounts.rb
@@ -38,6 +38,10 @@ FactoryBot.define do
     trait :without_sponsors_listing do
       has_sponsors_listing { false }
     end
+
+    trait :hidden do
+      hidden { true }
+    end
     
     trait :with_many_sponsors do
       sponsors_count { 100 }

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -17,7 +17,41 @@ class AccountMutualTest < ActiveSupport::TestCase
 end
 
 class AccountTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "hidden accounts are not imported again" do
+    account = create(:account, :hidden, login: "hidden-user")
+
+    assert_nil Account.attempt_import_from_repos(account.login)
+    assert_not_requested :get, account.repos_api_url
+  end
+
+  test "hidden accounts are not queued or synced" do
+    account = create(:account, :hidden)
+    account.define_singleton_method(:sync) { raise "hidden account was synced" }
+
+    assert_nil account.sync_async
+    assert_nil account.sync_all
+  end
+
+  test "sponsorship sync ignores a hidden sponsor" do
+    account = create(:account, login: "maintainer")
+    hidden_sponsor = create(:account, :hidden, login: "hidden-sponsor")
+    account.define_singleton_method(:fetch_all_sponsors) do |filter: nil|
+      filter == "active" ? [hidden_sponsor.login] : []
+    end
+
+    assert_no_difference "Sponsorship.count" do
+      account.sync_sponsorships
+    end
+  end
+
+  test "import from repos leaves hidden accounts unchanged" do
+    account = create(:account, :hidden, login: "hidden-user")
+    stub_request(:get, "https://repos.ecosyste.ms/api/v1/hosts/GitHub/owners/sponsors_logins")
+      .to_return(status: 200, body: [account.login].to_json)
+
+    Account.import_from_repos
+
+    assert_equal 1, Account.where("lower(login) = ?", account.login).count
+    assert account.reload.hidden?
+  end
 end

--- a/test/tasks/takedown_rake_test.rb
+++ b/test/tasks/takedown_rake_test.rb
@@ -1,0 +1,68 @@
+require "test_helper"
+require "rake"
+
+class TakedownRakeTest < ActiveSupport::TestCase
+  setup do
+    Rails.application.load_tasks unless Rake::Task.task_defined?("takedown:hide_user")
+    ENV.delete("LOGIN")
+  end
+
+  teardown do
+    ENV.delete("LOGIN")
+  end
+
+  test "hide_user hides and scrubs an account" do
+    account = create(
+      :account,
+      login: "target-user",
+      funded_count: 2,
+      last_synced_at: Time.current
+    )
+    other_account = create(:account, login: "other-user")
+    create(:sponsorship, funder: account, maintainer: other_account)
+    create(:sponsorship, funder: other_account, maintainer: account)
+    ENV["LOGIN"] = account.login.upcase
+
+    output, = capture_io { Rake::Task["takedown:hide_user"].execute }
+
+    account.reload
+    assert account.hidden?
+    assert_nil account.last_synced_at
+    assert_equal({}, account.data)
+    assert_equal({}, account.sponsor_profile)
+    assert_not account.has_sponsors_listing?
+    assert_equal 0, account.sponsors_count
+    assert_equal 0, account.funded_count
+    assert_equal 0, account.sponsorships_count
+    assert_equal 0, account.active_sponsorships_count
+    assert_equal 0, account.active_sponsors_count
+    assert_nil account.minimum_sponsorship_amount
+    assert_equal 0, Sponsorship.where(funder: account).or(Sponsorship.where(maintainer: account)).count
+    assert_includes output, "[sponsors] hidden account #{account.login}"
+    assert_includes output, "[sponsors] removed 2 sponsorships"
+  end
+
+  test "hide_user creates a hidden tombstone for an unknown account" do
+    ENV["LOGIN"] = "Missing-User"
+
+    capture_io { Rake::Task["takedown:hide_user"].execute }
+
+    account = Account.find_by(login: "missing-user")
+    assert account.hidden?
+  end
+
+  test "hide_user aborts without LOGIN" do
+    assert_raises(SystemExit) do
+      capture_io { Rake::Task["takedown:hide_user"].execute }
+    end
+  end
+
+  test "report describes the hidden account" do
+    account = create(:account, :hidden, login: "hidden-user")
+    ENV["LOGIN"] = account.login
+
+    output, = capture_io { Rake::Task["takedown:report"].execute }
+
+    assert_includes output, "[sponsors] hidden-user: account=hidden sponsorships=0"
+  end
+end


### PR DESCRIPTION
Adds `takedown:hide_user` and `takedown:report` for sponsor accounts. Hidden accounts are scrubbed, excluded from web and API responses, and prevented from being re-imported or synced.