### PR TITLE
Disable sessions and cookies so CDN can cache HTML

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  skip_forgery_protection
+  before_action { request.session_options[:skip] = true }
   include Pagy::Backend
 
   before_action :set_custom_headers

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,7 +8,6 @@
       <%= meta_title %>
     </title>
     <meta name="description" content="<%= meta_description %>">
-    <%= csrf_meta_tags %>
     <%= stylesheet_link_tag "application", :media => "all" %>
     <%= javascript_include_tag "application" %>
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,10 @@ module Sponsors
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks])
 
+    config.session_store :disabled
+    config.middleware.delete ActionDispatch::Session::CookieStore
+    config.middleware.delete ActionDispatch::Cookies
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ require 'sidekiq_unique_jobs/web'
 require 'sidekiq/web'
 
 Sidekiq::Web.use ActionDispatch::Cookies
-Sidekiq::Web.use ActionDispatch::Session::CookieStore, key: '_sponsors_sidekiq_session', path: '/sidekiq'
+Sidekiq::Web.use ActionDispatch::Session::CookieStore, key: '_sponsors_sidekiq_session', path: '/sidekiq', secure: Rails.env.production?
 Sidekiq::Web.use Rack::Auth::Basic do |username, password|
   ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(username), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_USERNAME"])) &
     ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(password), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_PASSWORD"]))

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 require 'sidekiq_unique_jobs/web'
 require 'sidekiq/web'
 
+Sidekiq::Web.use ActionDispatch::Cookies
+Sidekiq::Web.use ActionDispatch::Session::CookieStore, key: '_sponsors_sidekiq_session', path: '/sidekiq'
 Sidekiq::Web.use Rack::Auth::Basic do |username, password|
   ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(username), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_USERNAME"])) &
     ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(password), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_PASSWORD"]))

--- a/test/controllers/cache_headers_test.rb
+++ b/test/controllers/cache_headers_test.rb
@@ -31,4 +31,23 @@ class CacheHeadersTest < ActionDispatch::IntegrationTest
     assert_match(/s-maxage=3600/, cache_control)
     assert_match(/max-age=300/, cache_control)
   end
+
+  test "html pages do not set cookies" do
+    get root_url
+    assert_response :success
+    assert_nil response.headers['Set-Cookie']
+  end
+
+  test "account show does not set cookies" do
+    account = create(:account, login: 'cookietest')
+    get account_url(account)
+    assert_response :success
+    assert_nil response.headers['Set-Cookie']
+  end
+
+  test "api endpoints do not set cookies" do
+    get api_v1_accounts_url, as: :json
+    assert_response :success
+    assert_nil response.headers['Set-Cookie']
+  end
 end


### PR DESCRIPTION
`csrf_meta_tags` in the layout writes `_csrf_token` to the session on every render, which forces a `Set-Cookie: _sponsors_session=...` header on every response. Cloudflare (with origin cache control) returns `cf-cache-status: BYPASS` for responses carrying `Set-Cookie`, and APISIX `proxy-cache` never stores them, so the existing `s-maxage` cache headers are ignored:

```
$ curl -sI https://sponsors.ecosyste.ms/
set-cookie: _sponsors_session=...
apisix-cache-status: MISS
cf-cache-status: BYPASS
```

There's no login on this app, so:

- `config.session_store :disabled` and remove `ActionDispatch::Cookies` / `Session::CookieStore` from the middleware stack
- drop `csrf_meta_tags` from the layout
- `skip_forgery_protection` + `request.session_options[:skip] = true` in `ApplicationController`
- give `Sidekiq::Web` its own session middleware scoped to `/sidekiq` so retry/delete buttons keep working behind basic auth
- tests asserting no `Set-Cookie` on HTML and API responses

Same change as ecosyste-ms/awesome#793, which took `cf-cache-status: BYPASS` to `HIT` at both APISIX and Cloudflare.